### PR TITLE
CSPv3 with nonce support and stricter rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+interlock

--- a/src/auth.go
+++ b/src/auth.go
@@ -1,5 +1,6 @@
 // INTERLOCK | https://github.com/inversepath/interlock
 // Copyright (c) 2015-2016 Inverse Path S.r.l.
+// Copyright (c) 2016-2017 Marco Bonetti <sid77@slackware.it>
 //
 // Use of this source code is governed by the license
 // that can be found in the LICENSE file.
@@ -19,11 +20,19 @@ const cookieSize = 64
 const cookieAge = 8 * 60 * 60
 
 func randomString(size int) (c string, err error) {
+	return encodedRandomString(size, true)
+}
+
+func encodedRandomString(size int, URLEncoded bool) (c string, err error) {
 	rb := make([]byte, size)
 
 	_, err = rand.Read(rb)
 
-	c = base64.URLEncoding.EncodeToString(rb)
+	if URLEncoded {
+		c = base64.URLEncoding.EncodeToString(rb)
+	} else {
+		c = base64.StdEncoding.EncodeToString(rb)
+	}
 
 	return
 }

--- a/static/index.html
+++ b/static/index.html
@@ -8,9 +8,9 @@
     <link rel="icon" href="/favicon.ico" type="image/vnd.microsoft.icon" />
     <link rel="stylesheet" href="/styles/jquery-ui.css" type="text/css" />
     <link rel="stylesheet" href="/styles/interlock.css" type="text/css" />
-    <script src="/js/jquery-1.11.2.min.js"></script>
-    <script src="/js/jquery-ui-1.11.3.min.js"></script>
-    <script src="/js/interlock.js"></script>
+    <script nonce="{{ nonce }}" src="/js/jquery-1.11.2.min.js"></script>
+    <script nonce="{{ nonce }}" src="/js/jquery-ui-1.11.3.min.js"></script>
+    <script nonce="{{ nonce }}" src="/js/interlock.js"></script>
   </head>
 
   <body></body>


### PR DESCRIPTION
Hi 👋  ,
This is a spike for adding CSPv3 with nonce support and a stricter rules set as well.

CSPv3 is still a working draft and currently supported by the latest stable versions of Chrome only, Firefox just recently added support for the `'strict-dynamic'` keyword which is expected to be rolled out with the next stable version (52.0).

From my tests, though, current code base doesn't require `'strict-dynamic'` support, I left it there as a possible solution for removing `'unsafe-eval'` (see below).

What is currently provided:

- `src/auth.go` can now outputs both URL-encoded and standard base64 strings, I believe URL-encoded `randomString()` output could have worked as well for CSP nonces but I preferred to provide the standard base64 version for them. At this point it might make sense to move this function outside `src/auth.go` and into a proper utilities package. Or maybe not 😄 

- `src/api.go` is now serving a stricter CSPv3 header and provides CSP nonce support as well. I've implemented it with a custom `http.ResponseWriter` for static contents which replace any occurrence of `{{ nonce }}` in the body with the currently injected CSP nonce from the header. Again: does it make sense to move all of this into a new `src/csp.go` package or something like that?

- `static/index.html` has been updated to use the `{{ nonce }}` token mentioned above

- `.gitignore` ignores the built ./interlock binary, which presence was driving me crazy during development 😛 

What is missing:

- `'unsafe-eval'` should be removed from current CSP rules set

- maybe some code cleanup

Regarding `'unsafe-eval'`: to my understanding, this entry is currently needed to allow dynamic script loading with jQuery `getScript()`. The entry should go away for a robust CSP rule set, otherwise an attacker can execute possibly injected code.

I'm still trying to work around the need of `'unsafe-eval'`, maybe leveraging `'strict-dynamic'` as mentioned above.

Anyway, before submitting more code I'd like to see if this spike makes sense for futures development of interlock. What do you think?

Cheers,
Marco