### PR TITLE
Signal UI improvements.

### DIFF
--- a/static/js/signal.js
+++ b/static/js/signal.js
@@ -108,8 +108,14 @@ Interlock.Signal.getHistoryCallback = function(backendData, args) {
       /* ensure that the history poller for the selected contact is
          still active before to actually refresh the chat history */
       if (Interlock.Signal.historyPollerInterval[args.contact] > 0) {
-          $('#history').text(backendData.response);
-          $('#history').scrollTop(10000);
+        if ($('#history').text() !== backendData.response) {
+          if ($('#history').scrollTop() + $('#history').height() === $('#history').prop('scrollHeight')) {
+            $('#history').text(backendData.response);
+            $('#history').scrollTop($('#history').prop('scrollHeight'));
+          } else {
+            $('#history').text(backendData.response);
+          }
+        }
       }
     } else {
       Interlock.Session.createEvent({'kind': backendData.status,

--- a/static/styles/interlock.css
+++ b/static/styles/interlock.css
@@ -546,7 +546,7 @@ h1 {
 }
 
 .history_contents {
-  height: 337px;
+  height: 333px;
   overflow-y: auto;
   white-space: pre-wrap;
   word-wrap: break-word;

--- a/static/styles/interlock.css
+++ b/static/styles/interlock.css
@@ -548,6 +548,9 @@ h1 {
 .history_contents {
   height: 337px;
   overflow-y: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-all;
 }
 
 .ui-widget-content textarea.key::-webkit-input-placeholder { font-family: 'Arial', sans-serif }


### PR DESCRIPTION
I tested the signal app and here is a couple of improvements I would suggest, each in its own commit:
* Wrap lines into the chat to avoid any horizontal scrolling.
* I had two vertical scroll bars because the chat area was too big, reducing the height to 333 pixels made one scroll bar go away. I'm using Firefox if you are interested to know.
* Finally, the callback loop executing every 5 seconds and scrolling to 10000 can be cumbersome. I changed the behavior to change the text only if backendData.response differs and also scroll the text to the end (not using a hardcoded value) only when the scroll is already on the bottom. It makes copy pasting way easier during a chat.

Comments or suggestions are welcome (I'm not really familiar with jquery, css and js).